### PR TITLE
Fixes for 0.5

### DIFF
--- a/src/SecureSessions.jl
+++ b/src/SecureSessions.jl
@@ -31,9 +31,9 @@ key_length      = 32                   # Key length for AES 256-bit cipher in CB
 block_size      = 16                   # IV  length for AES 256-bit cipher in CBC mode
 const_key       = csrng(key_length)    # Symmetric key for encrypting secret_keys (with 256-bit encryption)
 const_iv        = csrng(block_size)    # IV for encrypting secret_keys
-http_only       = true 
+http_only       = true
 encrypted_sessions_only = true
-timeout_str     = utf8(string(convert(Int64, 0.001 * session_timeout)))    # Session timeout in seconds, represented as a string
+timeout_str     = string(convert(Int64, 0.001 * session_timeout))    # Session timeout in seconds, represented as a string
 
 
 end # module

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -75,7 +75,7 @@ Returns: Milliseconds since the epoch.
 Takes 13 characters (valid until some time around the year 2287).
 """
 function get_timestamp()
-    1000 * convert(Int, Dates.datetime2unix(now()))
+    Int(round(1000*Dates.datetime2unix(now())))
 end
 
 
@@ -87,7 +87,7 @@ function num_to_bytearray(x)
     io = IOBuffer()
     write(io, x)
     seekstart(io)
-    readbytes(io)
+    read(io)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ function app(req::Request)
     res = Response()
     uri = URI(req.resource)
     if uri.path == "/set_secure_cookie"
-	data = bytestring(req.data)
+	data = String(copy(req.data))
 	create_secure_session_cookie(data, res, "sessionid")
     elseif uri.path == "/read_cookie"
         res.data = get_session_cookie_data(req, "sessionid")
@@ -52,7 +52,7 @@ res1     = Requests.post("http://localhost:8000/set_secure_cookie"; data = usern
 # Compare the returned data to the data originally encrypted.
 cookie = res1.cookies["sessionid"]
 res2   = Requests.post("http://localhost:8000/read_cookie"; cookies = [cookie])
-@test bytestring(res2.data) == username
+@test String(copy(res2.data)) == username
 
 
 ##################################################


### PR DESCRIPTION
Use new string methods, and avoid inexact error when converting floats to integers in timestamp routine.